### PR TITLE
Updates coraza, uses parseServerName

### DIFF
--- a/coraza.go
+++ b/coraza.go
@@ -101,7 +101,7 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 	repl.Set("http.transaction_id", id)
 
-	it, err := processRequest(tx, r)
+	it, err := processRequest(tx, r, m.logger)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/caddyserver/caddy/v2 v2.6.2
-	github.com/corazawaf/coraza/v3 v3.0.0-20230117071831-8b909c7fc345
+	github.com/corazawaf/coraza/v3 v3.0.0-20230203020113-719e7edfc0ac
 	go.uber.org/zap v1.24.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/corazawaf/coraza/v3 v3.0.0-20230117071831-8b909c7fc345 h1:4xW94n5Lah6ca8ROtP1g9fhVHc8RW5IyMnLVp3uzkUo=
 github.com/corazawaf/coraza/v3 v3.0.0-20230117071831-8b909c7fc345/go.mod h1:kLh41mCKAXAX7e/Rv3LijMyHObu3B6IbdcflFarf858=
+github.com/corazawaf/coraza/v3 v3.0.0-20230203020113-719e7edfc0ac h1:7Z7S20RGR6kZNBjjhP0bPWdgVQuF1XqNIxxl9myBt/o=
+github.com/corazawaf/coraza/v3 v3.0.0-20230203020113-719e7edfc0ac/go.mod h1:dXFswKzaDVm4SsHAyvi12A4yLfg2bVx/myCBkyGALGU=
 github.com/corazawaf/libinjection-go v0.1.2 h1:oeiV9pc5rvJ+2oqOqXEAMJousPpGiup6f7Y3nZj5GoM=
 github.com/corazawaf/libinjection-go v0.1.2/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/http.go
+++ b/http.go
@@ -24,9 +24,10 @@ import (
 	"strings"
 
 	"github.com/corazawaf/coraza/v3/types"
+	"go.uber.org/zap"
 )
 
-func processRequest(tx types.Transaction, r *http.Request) (*types.Interruption, error) {
+func processRequest(tx types.Transaction, r *http.Request, logger *zap.Logger) (*types.Interruption, error) {
 	// first we parse the r.RemoteAddr, it could be an IP or an IP:PORT or a [IP]:PORT
 	remoteAddr := r.RemoteAddr
 	remotePort := ""
@@ -46,7 +47,8 @@ func processRequest(tx types.Transaction, r *http.Request) (*types.Interruption,
 	tx.AddRequestHeader("Host", r.Host)
 	serverName, err := parseServerName(r.Host)
 	if err != nil {
-		// TODO: log a warning, parseServerName still populates serverName
+		// Even if an error is raised, serverName is still populated
+		logger.Debug("Failed to parse server name from host", zap.String("host", r.Host), zap.Error(err))
 	}
 	tx.SetServerName(serverName)
 	if it := tx.ProcessRequestHeaders(); it != nil {

--- a/http_test.go
+++ b/http_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/corazawaf/coraza/v3"
+	"go.uber.org/zap"
 )
 
 func TestHTTP(t *testing.T) {
@@ -32,6 +33,7 @@ SecRule ARGS "456" "id:1,phase:2,deny,status:403"
 	if err != nil {
 		t.Error(err)
 	}
+	logger, _ := zap.NewDevelopment()
 	tx := waf.NewTransaction()
 	// we build a sample POST request
 	r, err := http.NewRequest("POST", "/sample.php", strings.NewReader("test=456"))
@@ -39,7 +41,7 @@ SecRule ARGS "456" "id:1,phase:2,deny,status:403"
 		t.Error(err)
 	}
 	r.Header.Add("Content-Type", "x-www-form-urlencoded")
-	it, err := processRequest(tx, r)
+	it, err := processRequest(tx, r, logger)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION

This PR follows the API update in Coraza Core that includes `SetServerName`. The function has to be called by the connector to properly populate the server name.

- Follows  https://github.com/corazawaf/coraza/pull/572
- Sibling of https://github.com/corazawaf/coraza-proxy-wasm/pull/142

Closes https://github.com/corazawaf/coraza-caddy/issues/35
