### PR TITLE
chore: deprecates Include config field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ OWASP Coraza WAF is 100% compatible with OWASP Coreruleset and Modsecurity synta
 ```caddy
 coraza_waf {
  directives `
+  Include /path/to/config.conf
   SecAction "id:1,pass,log"
  `
- include /path/to/config.conf
 }
 ```
 
 Sample usage:  
-Important: `order coraza_waf first` must be always included in your Caddyfile for Coraza module to work
+
+**Important:** `order coraza_waf first` must be always included in your Caddyfile for Coraza module to work
 
 ```caddy
 {
@@ -33,10 +34,10 @@ http://127.0.0.1:8080 {
    SecAction "id:1,pass,log"
    SecRule REQUEST_URI "/test5" "id:2, deny, log, phase:1"
    SecRule REQUEST_URI "/test6" "id:4, deny, log, phase:3"
+   Include file1.conf 
+   Include file2.conf
+   Include /some/path/*.conf
   `
-  include file1.conf 
-  include file2.conf
-  include /some/path/*.conf
  }
  reverse_proxy http://192.168.1.15:8080
 }
@@ -55,16 +56,14 @@ xcaddy build --with github.com/corazawaf/coraza-caddy
 You may run the test suite by executing:
 
 ```shell
-git clone https://github.com/corazawaf/coraza-caddy
-cd coraza-caddy
-go test ./...`
+go run mage.go test
 ```
 
 ## Using OWASP Core Ruleset
 
 Clone the [coreruleset repository](https://github.com/coreruleset/coreruleset) and download the default coraza configurations from [Coraza repository](https://raw.githubusercontent.com/corazawaf/coraza/v2/master/coraza.conf-recommended), then add the following to you coraza_waf directive:
 
-```
+```seclang
 include caddypath/coraza.conf-recommended
 include caddypath/coreruleset/crs-setup.conf.example
 include caddypath/coreruleset/rules/*.conf

--- a/coraza.go
+++ b/coraza.go
@@ -27,6 +27,7 @@ func init() {
 
 // corazaModule is a Web Application Firewall implementation for Caddy.
 type corazaModule struct {
+	// deprecated
 	Include    []string `json:"include"`
 	Directives string   `json:"directives"`
 
@@ -54,8 +55,8 @@ func (m *corazaModule) Provision(ctx caddy.Context) error {
 		config = config.WithDirectives(m.Directives)
 	}
 
-	m.logger.Debug("Preparing to include files", zap.Int("count", len(m.Include)), zap.Strings("files", m.Include))
 	if len(m.Include) > 0 {
+		m.logger.Warn("Include field is deprected, do the include in directives instead")
 		for _, file := range m.Include {
 			if strings.Contains(file, "*") {
 				m.logger.Debug("Preparing to expand glob", zap.String("pattern", file))

--- a/coraza.go
+++ b/coraza.go
@@ -56,7 +56,7 @@ func (m *corazaModule) Provision(ctx caddy.Context) error {
 	}
 
 	if len(m.Include) > 0 {
-		m.logger.Warn("include field is deprecated, please use the Include directive instead")
+		m.logger.Warn("include field is deprecated, please use the Include directive inside 'directives' field instead")
 		for _, file := range m.Include {
 			if strings.Contains(file, "*") {
 				m.logger.Debug("Preparing to expand glob", zap.String("pattern", file))

--- a/coraza.go
+++ b/coraza.go
@@ -56,7 +56,7 @@ func (m *corazaModule) Provision(ctx caddy.Context) error {
 	}
 
 	if len(m.Include) > 0 {
-		m.logger.Warn("Include field is deprected, do the include in directives instead")
+		m.logger.Warn("include field is deprecated, please use the Include directive instead")
 		for _, file := range m.Include {
 			if strings.Contains(file, "*") {
 				m.logger.Debug("Preparing to expand glob", zap.String("pattern", file))


### PR DESCRIPTION
It can be done in 'directives' field and only causes confusion with respect to ordering of rules which is something that matters when it comes to disruptive actions.