### PR TITLE
chore: removes the warning and fallback to the authority.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/corazawaf/coraza/v3 v3.0.0-rc.3
 	github.com/jcchavezs/mergefs v0.0.0-20230405222254-20429875efdd
 	github.com/magefile/mage v1.15.0
+	github.com/stretchr/testify v1.8.2
 	go.uber.org/zap v1.24.0
 )
 
@@ -29,6 +30,7 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/corazawaf/libinjection-go v0.1.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/badger v1.6.2 // indirect
 	github.com/dgraph-io/badger/v2 v2.2007.4 // indirect
 	github.com/dgraph-io/ristretto v0.0.4-0.20200906165740-41ebdbffecfd // indirect
@@ -83,6 +85,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4 // indirect
 	github.com/petar-dambovaliev/aho-corasick v0.0.0-20211021192214-5ab2d9280aa9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect

--- a/http.go
+++ b/http.go
@@ -43,11 +43,7 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 	if req.Host != "" {
 		tx.AddRequestHeader("Host", req.Host)
 		// This connector relies on the host header (now host field) to populate ServerName
-		serverName, err := parseServerName(req.Host)
-		if err != nil {
-			tx.DebugLogger().Warn().Err(err).Msg("failed to parse server name")
-		}
-		tx.SetServerName(serverName)
+		tx.SetServerName(parseServerName(req.Host))
 	}
 
 	// Transfer-Encoding header is removed by go/http
@@ -111,13 +107,11 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 }
 
 // parseServerName parses r.Host in order to retrieve the virtual host.
-func parseServerName(host string) (string, error) {
+func parseServerName(host string) string {
 	serverName, _, err := net.SplitHostPort(host)
 	if err != nil {
-		// missing port or bad format
-		err = fmt.Errorf("failed to parse server name from authority %q, %v", host, err)
-		serverName = host
+		return host
 	}
 	// anyways serverName is returned
-	return serverName, err
+	return serverName
 }

--- a/http_test.go
+++ b/http_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/corazawaf/coraza/v3"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHTTP(t *testing.T) {
@@ -35,4 +36,9 @@ SecRule ARGS "456" "id:1,phase:2,deny,status:403"
 	if it != nil {
 		t.Error("transaction should be interrupted")
 	}
+}
+
+func TestParseServerName(t *testing.T) {
+	require.Equal(t, "www.example.com", parseServerName("www.example.com"))
+	require.Equal(t, "1.2.3.4", parseServerName("1.2.3.4:80"))
 }


### PR DESCRIPTION
When the parseServerName used to fail because port wasn't present we produced a log warning which wasn't accurante nor actionable. In this commit it is being removed and relaxes the parsing to a best effort.

Closes #70

Ping @ericswpark