### PR TITLE
fix: fixes the package naming following the best practices from go modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ http://127.0.0.1:8080 {
 Run:
 
 ```shell
-xcaddy build --with github.com/corazawaf/coraza-caddy
+xcaddy build --with github.com/corazawaf/coraza-caddy/v2
 ```
 
 ## Testing

--- a/caddy/main.go
+++ b/caddy/main.go
@@ -7,7 +7,7 @@ import (
 	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 	_ "github.com/caddyserver/caddy/v2/modules/standard"
 
-	_ "github.com/corazawaf/coraza-caddy"
+	_ "github.com/corazawaf/coraza-caddy/v2"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/corazawaf/coraza-caddy
+module github.com/corazawaf/coraza-caddy/v2
 
 go 1.18
 
@@ -142,9 +142,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.0 // indirect
 	rsc.io/binaryregexp v0.2.0 // indirect
-)
-
-retract (
-	[v1.0.0, v1.2.2]
-	v1.0.0-beta.1
 )

--- a/magefile.go
+++ b/magefile.go
@@ -41,7 +41,7 @@ func Format() error {
 	return sh.RunV("go", "run", fmt.Sprintf("github.com/rinchsan/gosimports/cmd/gosimports@%s", gosImportsVer),
 		"-w",
 		"-local",
-		"github.com/corazawaf/coraza-caddy",
+		"github.com/corazawaf/coraza-caddy/v2",
 		".")
 }
 
@@ -154,7 +154,7 @@ func buildCaddy(goos string) error {
 	if os.Getenv("CADDY_VERSION") != "" {
 		buildArgs = append(buildArgs, os.Getenv("CADDY_VERSION"))
 	}
-	buildArgs = append(buildArgs, "--with", "github.com/corazawaf/coraza-caddy=.",
+	buildArgs = append(buildArgs, "--with", "github.com/corazawaf/coraza-caddy/v2=.",
 		"--output", buildDir)
 
 	return sh.RunWithV(env, "xcaddy", buildArgs...)


### PR DESCRIPTION
See https://go.dev/doc/modules/version-numbers\#major-version.

Fixes https://github.com/corazawaf/coraza-caddy/issues/68