### PR TITLE
chore: automates coraza upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "github.com/corazawaf/coraza/v3"
+        dependency-type: "direct"
+    target-branch: "main"


### PR DESCRIPTION
Adds dependabot to automate coraza upgrade. This helps to automate dependency update as discussed in the monthly meeting https://github.com/corazawaf/coraza/issues/814 at https://owasp.slack.com/archives/C02BXH135AT/p1687956451711449