### PR TITLE
Adds stale bot for awaiting-feedback issues

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,23 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v3
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue has been open 30 days waiting for feedback. Remove the stale label or comment, or this will be closed in 14 days."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          only-issue-labels: "awaiting feedback"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR proposes to use also in this repo the stale label "awaiting feedback", also used in the Coraza repo: https://github.com/corazawaf/coraza/pull/793.
It would be handy for issues like: https://github.com/corazawaf/coraza-caddy/issues?q=is%3Aissue+is%3Aopen+label%3A%22awaiting+feedback%22