### PR TITLE
chore: keep the handler error instead of trying to hijack it as it breaks the user experience.

### DIFF
--- a/coraza.go
+++ b/coraza.go
@@ -4,6 +4,7 @@
 package coraza
 
 import (
+	"errors"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -91,6 +92,8 @@ func (m *corazaModule) Validate() error {
 	return nil
 }
 
+var errInterruptionTriggered = errors.New("interruption triggered")
+
 // ServeHTTP implements caddyhttp.MiddlewareHandler.
 func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	id := randomString(16)
@@ -115,39 +118,26 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	// It fails if any of these functions returns an error and it stops on interruption.
 	if it, err := processRequest(tx, r); err != nil {
 		return caddyhttp.HandlerError{
-			StatusCode: 500,
+			StatusCode: http.StatusInternalServerError,
 			ID:         tx.ID(),
 			Err:        err,
 		}
 	} else if it != nil {
-		w.WriteHeader(obtainStatusCodeFromInterruptionOrDefault(it, http.StatusOK))
-		return nil
+		return caddyhttp.HandlerError{
+			StatusCode: obtainStatusCodeFromInterruptionOrDefault(it, http.StatusOK),
+			ID:         tx.ID(),
+			Err:        errInterruptionTriggered,
+		}
 	}
 
 	ww, processResponse := wrap(w, r, tx)
 
 	// We continue with the other middlewares by catching the response
 	if err := next.ServeHTTP(ww, r); err != nil {
-		if hErr, ok := err.(caddyhttp.HandlerError); ok {
-			return hErr
-		} else {
-			return caddyhttp.HandlerError{
-				StatusCode: 500,
-				ID:         tx.ID(),
-				Err:        err,
-			}
-		}
+		return err
 	}
 
-	if err := processResponse(tx, r); err != nil {
-		return caddyhttp.HandlerError{
-			StatusCode: 500,
-			ID:         tx.ID(),
-			Err:        err,
-		}
-	}
-
-	return nil
+	return processResponse(tx, r)
 }
 
 // Unmarshal Caddyfile implements caddyfile.Unmarshaler.

--- a/coraza.go
+++ b/coraza.go
@@ -128,10 +128,14 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 
 	// We continue with the other middlewares by catching the response
 	if err := next.ServeHTTP(ww, r); err != nil {
-		return caddyhttp.HandlerError{
-			StatusCode: 500,
-			ID:         tx.ID(),
-			Err:        err,
+		if hErr, ok := err.(caddyhttp.HandlerError); ok {
+			return hErr
+		} else {
+			return caddyhttp.HandlerError{
+				StatusCode: 500,
+				ID:         tx.ID(),
+				Err:        err,
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently when a later in the chain middleware returned an error with a certain status code, we attempted to wrap that error with an own error which lead to misleading behaviours

Closes https://github.com/corazawaf/coraza-caddy/issues/83.

Ping @rasschaert