### PR TITLE
Fix double line break for erros in console output

### DIFF
--- a/coraza.go
+++ b/coraza.go
@@ -189,7 +189,7 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 
 func newErrorCb(logger *zap.Logger) func(types.MatchedRule) {
 	return func(mr types.MatchedRule) {
-		logMsg := mr.ErrorLog()
+		logMsg := strings.TrimRight(mr.ErrorLog(), "\n")
 		switch mr.Rule().Severity() {
 		case types.RuleSeverityEmergency,
 			types.RuleSeverityAlert,


### PR DESCRIPTION
It seems that the some error messages already come with a new line from Coraza WAF and the logger used in `coraza.go` also adds a new line.

So I trimmed the extra "\n" from the message.

![image](https://github.com/corazawaf/coraza-caddy/assets/71379045/85de662b-36d2-45f8-85e0-6d879b6ef090)
