### PR TITLE
chore: allows to run the nightly per commit.

### DIFF
--- a/.github/workflows/nightly-caddy.yml
+++ b/.github/workflows/nightly-caddy.yml
@@ -5,6 +5,12 @@ on:
       - ".github/workflows/nightly-caddy.yml"
   schedule:
     - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      caddyversion:
+        description: "caddy version"
+        required: true
+        default: "master"
 
 jobs:
   nightly-caddy:
@@ -30,7 +36,7 @@ jobs:
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@${{ matrix.xcaddy-version }}
 
       - name: Build caddy
-        run: CADDY_VERSION=master go run mage.go buildCaddyLinux
+        run: CADDY_VERSION=${{ inputs.caddyversion }} go run mage.go buildCaddyLinux
 
       - name: Run e2e tests
         run: go run mage.go e2e

--- a/.github/workflows/nightly-caddy.yml
+++ b/.github/workflows/nightly-caddy.yml
@@ -8,9 +8,8 @@ on:
   workflow_dispatch:
     inputs:
       caddyversion:
-        description: "caddy version"
+        description: "caddy version (branch, tag or commit)"
         required: true
-        default: "master"
 
 jobs:
   nightly-caddy:
@@ -36,7 +35,7 @@ jobs:
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@${{ matrix.xcaddy-version }}
 
       - name: Build caddy
-        run: CADDY_VERSION=${{ inputs.caddyversion }} go run mage.go buildCaddyLinux
+        run: CADDY_VERSION=${{ github.event.inputs.caddyversion || 'master' }} go run mage.go buildCaddyLinux
 
       - name: Run e2e tests
         run: go run mage.go e2e


### PR DESCRIPTION
The nightly is failing due to latest changes in caddy (see https://github.com/corazawaf/coraza-caddy/actions/workflows/nightly-caddy.yml) however there are two PRs merged as candidates. This PR allows us to run the nightly with a commit input so we can figure out which one is it.

The nightly job is expected to fail.