### PR TITLE
chore: upgrades go to 1.21 ad xcaddy to 0.3.5.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: v1.20.x
+          go-version: v1.21.x
           cache: true
 
       - run: go run mage.go lint

--- a/.github/workflows/nightly-caddy.yml
+++ b/.github/workflows/nightly-caddy.yml
@@ -16,9 +16,9 @@ jobs:
     name: "Nightly Caddy (caddy version: ${{ github.event.inputs.caddyversion || 'master' }})"
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         os: [ubuntu-latest]
-        xcaddy-version: [v0.3.2]
+        xcaddy-version: [v0.3.5]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go

--- a/.github/workflows/nightly-coraza.yml
+++ b/.github/workflows/nightly-coraza.yml
@@ -10,9 +10,9 @@ jobs:
   nightly-coraza:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         os: [ubuntu-latest]
-        xcaddy-version: [v0.3.2]
+        xcaddy-version: [v0.3.5]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,9 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         os: [ubuntu-latest]
-        xcaddy-version: [v0.3.2]
+        xcaddy-version: [v0.3.5]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go


### PR DESCRIPTION
Currently nightly for caddy is failing because it needs go 1.21. 

Ref https://github.com/corazawaf/coraza-caddy/actions/runs/7683339431/job/20938620088#step:5:68