### PR TITLE
test: fix ftw log-file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,5 +50,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: ftw-envoy-logs
-          path: build/ftw-envoy.log
+          name: ftw-caddy-logs
+          path: build/ftw-caddy.log


### PR DESCRIPTION
Fixes the following warning of the `tests` action/workflow:

```
Run actions/upload-artifact@v4
Warning: No files were found with the provided path: build/ftw-envoy.log. No artifacts will be uploaded.
```

The [log-file name was incorrect](https://github.com/corazawaf/coraza-caddy/blob/main/ftw/docker-compose.yml#L49).