### PR TITLE
use a snippet in the example

### DIFF
--- a/example/Caddyfile
+++ b/example/Caddyfile
@@ -10,7 +10,7 @@
 	}
 }
 
-:8080 {
+(waf) {
 	coraza_waf {
 		load_owasp_crs
 		directives `
@@ -42,6 +42,14 @@
 		file_server
 		templates
 	}
+}
 
+:8080 {
+	import waf
 	reverse_proxy {$HTTPBIN_HOST:localhost}:8081
 }
+
+# waf-test.example.com {
+#	import waf
+#	reverse_proxy 192.0.2.80:8080
+# }


### PR DESCRIPTION
If you're using Caddy as a reverse proxy for a bunch of internal services you can simply `import waf` (or whatever you called the snippet) in each of your handlers you want to protect, and define a common protection configuration that you can apply to all of your sites/vhosts in a snippet called `(waf)`.

If the WAF is breaking one of your sites, you can simply comment out the import, and `caddy reload`.