### PR TITLE
Feature/hostname logging v5

### DIFF
--- a/coraza.go
+++ b/coraza.go
@@ -92,14 +92,17 @@ func (m *corazaModule) Validate() error {
 // ServeHTTP implements caddyhttp.MiddlewareHandler.
 func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	var err error
-	id := randomString(16)
-	tx := m.waf.NewTransactionWithID(id)
+	tx := m.waf.NewTransaction()
 	defer func() {
 		if tx.IsInterrupted() {
+			// Get unique_id from transaction data
+			uniqueID := tx.GetCollection(types.UNIQUE_ID).Get("UNIQUE_ID")
+
+			// Log hostname with unique_id and better message
 			m.logger.Error("WAF rule violation detected",
 				zap.String("hostname", r.Host),
 				zap.String("uri", r.RequestURI),
-				zap.String("unique_id", tx.ID()),
+				zap.String("unique_id", uniqueID),
 				zap.String("client_ip", r.RemoteAddr),
 			)
 		}
@@ -107,14 +110,14 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 		_ = tx.Close()
 	}()
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
-	repl.Set("http.transaction_id", id)
+	repl.Set("http.transaction_id", tx.ID())
 
 	it, err := processRequest(tx, r)
 	if err != nil {
 		return err
 	}
 	if it != nil {
-		return interrupt(nil, tx, id)
+		return interrupt(nil, tx, tx.ID())
 	}
 
 	rec := newStreamRecorder(w, tx)
@@ -124,7 +127,7 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	}
 	// If the response was interrupted during phase 3 or 4 we can stop the response
 	if tx.IsInterrupted() {
-		return interrupt(nil, tx, id)
+		return interrupt(nil, tx, tx.ID())
 	}
 	if !rec.Buffered() {
 		//Nothing to do, response was already sent to the client

--- a/coraza.go
+++ b/coraza.go
@@ -95,10 +95,13 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	tx := m.waf.NewTransaction()
 	defer func() {
 		if tx.IsInterrupted() {
+			// Get unique_id from transaction variables
+			uniqueID := tx.Variables().GetCollection(types.VARIABLE_UNIQUE_ID).Get("UNIQUE_ID")
 			m.logger.Error("WAF rule violation detected",
 				zap.String("hostname", r.Host),
 				zap.String("uri", r.RequestURI),
 				zap.String("client_ip", r.RemoteAddr),
+				zap.String("unique_id", uniqueID),
 			)
 		}
 		tx.ProcessLogging()

--- a/coraza.go
+++ b/coraza.go
@@ -95,6 +95,9 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	id := randomString(16)
 	tx := m.waf.NewTransactionWithID(id)
 	defer func() {
+		if tx.IsInterrupted() {
+			m.logger = m.logger.With(zap.String("host", r.Host))
+		}
 		tx.ProcessLogging()
 		_ = tx.Close()
 	}()

--- a/coraza.go
+++ b/coraza.go
@@ -95,14 +95,10 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	tx := m.waf.NewTransaction()
 	defer func() {
 		if tx.IsInterrupted() {
-			// Get unique_id from transaction data
-			uniqueID := tx.GetCollection(types.UNIQUE_ID).Get("UNIQUE_ID")
-
-			// Log hostname with unique_id and better message
+			// Log hostname with better message
 			m.logger.Error("WAF rule violation detected",
 				zap.String("hostname", r.Host),
 				zap.String("uri", r.RequestURI),
-				zap.String("unique_id", uniqueID),
 				zap.String("client_ip", r.RemoteAddr),
 			)
 		}

--- a/coraza.go
+++ b/coraza.go
@@ -95,7 +95,6 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	tx := m.waf.NewTransaction()
 	defer func() {
 		if tx.IsInterrupted() {
-			// Log hostname with better message
 			m.logger.Error("WAF rule violation detected",
 				zap.String("hostname", r.Host),
 				zap.String("uri", r.RequestURI),
@@ -106,14 +105,14 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 		_ = tx.Close()
 	}()
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
-	repl.Set("http.transaction_id", tx.ID())
+	repl.Set("http.transaction_id", "")
 
 	it, err := processRequest(tx, r)
 	if err != nil {
 		return err
 	}
 	if it != nil {
-		return interrupt(nil, tx, tx.ID())
+		return interrupt(nil, tx, "")
 	}
 
 	rec := newStreamRecorder(w, tx)
@@ -121,19 +120,16 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	if err != nil {
 		return err
 	}
-	// If the response was interrupted during phase 3 or 4 we can stop the response
 	if tx.IsInterrupted() {
-		return interrupt(nil, tx, tx.ID())
+		return interrupt(nil, tx, "")
 	}
 	if !rec.Buffered() {
-		//Nothing to do, response was already sent to the client
 		return nil
 	}
 
 	if status := rec.Status(); status > 0 {
 		w.WriteHeader(status)
 	}
-	// We will send the response provided by Coraza
 	reader, err := rec.Reader()
 	if err != nil {
 		return err

--- a/coraza.go
+++ b/coraza.go
@@ -96,7 +96,10 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	tx := m.waf.NewTransactionWithID(id)
 	defer func() {
 		if tx.IsInterrupted() {
-			m.logger = m.logger.With(zap.String("host", r.Host))
+			m.logger.Error("WAF interrupt",
+				zap.String("hostname", r.Host),
+				zap.String("uri", r.RequestURI),
+			)
 		}
 		tx.ProcessLogging()
 		_ = tx.Close()

--- a/coraza.go
+++ b/coraza.go
@@ -96,9 +96,11 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	tx := m.waf.NewTransactionWithID(id)
 	defer func() {
 		if tx.IsInterrupted() {
-			m.logger.Error("WAF interrupt",
+			m.logger.Error("WAF rule violation detected",
 				zap.String("hostname", r.Host),
 				zap.String("uri", r.RequestURI),
+				zap.String("unique_id", tx.ID()),
+				zap.String("client_ip", r.RemoteAddr),
 			)
 		}
 		tx.ProcessLogging()

--- a/coraza.go
+++ b/coraza.go
@@ -95,8 +95,21 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	tx := m.waf.NewTransaction()
 	defer func() {
 		if tx.IsInterrupted() {
-			// Get unique_id from transaction variables
-			uniqueID := tx.Variables().GetCollection(types.VARIABLE_UNIQUE_ID).Get("UNIQUE_ID")
+			// Get the unique_id from the matched rules
+			var uniqueID string
+			for _, rule := range tx.MatchedRules() {
+				if meta := rule.ErrorLog(403); meta != "" {
+					// Extract unique_id from the error log
+					if idx := strings.Index(meta, "[unique_id \""); idx != -1 {
+						end := strings.Index(meta[idx:], "\"]")
+						if end != -1 {
+							uniqueID = meta[idx+12 : idx+end]
+							break
+						}
+					}
+				}
+			}
+
 			m.logger.Error("WAF rule violation detected",
 				zap.String("hostname", r.Host),
 				zap.String("uri", r.RequestURI),

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/corazawaf/coraza-caddy
+module github.com/stardothosting/coraza-caddy
 
 go 1.18
 


### PR DESCRIPTION
# Add unique_id to WAF violation logs

## Changes
- Added hostname to WAF violation logs
- Added unique_id extraction from matched rules
- Improved log correlation between detailed Coraza logs and summary logs

## Example Log Output

```
{
"level": "error",
"logger": "http.handlers.waf",
"msg": "WAF rule violation detected",
"hostname": "example.com",
"uri": "/?s=../../etc/passwd",
"client_ip": "10.0.0.1:12345",
"unique_id": "TJDwCHtXQPLaaQFhqry"
}
```
## Testing Done
- Tested with path traversal attacks
- Verified unique_id correlation with detailed Coraza logs
- Confirmed hostname logging works correctly
