### PR TITLE
Call PrepareRequest to populate computed request values

### DIFF
--- a/coraza.go
+++ b/coraza.go
@@ -113,6 +113,9 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 	repl.Set("http.transaction_id", id)
 
+	server := r.Context().Value(caddyhttp.ServerCtxKey).(*caddyhttp.Server)
+	caddyhttp.PrepareRequest(r, repl, w, server)
+
 	// ProcessRequest is just a wrapper around ProcessConnection, ProcessURI,
 	// ProcessRequestHeaders and ProcessRequestBody.
 	// It fails if any of these functions returns an error and it stops on interruption.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Stonework4292/coraza-caddy
+module github.com/corazawaf/coraza-caddy/v2
 
 go 1.23.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/corazawaf/coraza-caddy/v2
+module github.com/Stonework4292/coraza-caddy
 
 go 1.23.0
 


### PR DESCRIPTION
Ensure that the `client_ip` caddy variable value is set correctly when `trusted_proxies` are configured in the Caddyfile. In this case, the `client_ip` should be read from the `X-Forwarded-For` header so that the WAF block logs report the correct `client_ip`.

This fixes a bug where `coraza-caddy` always reported the `remote_addr` which in setup behind another proxy would hide the original source ip.