### PR TITLE
renovate: add gomodTidy as postUpdateOptions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,8 @@
   ],
   "constraints": {
     "go": "1.23"
-  }
+  },
+  "postUpdateOptions": [
+    "gomodTidy"
+  ]
 }


### PR DESCRIPTION
We always have to manually do mod tidy https://github.com/corazawaf/coraza-caddy/pull/231 and because of that at least two people are needed to approve a PR.