### PR TITLE
fix(nightly): don't update dependencies during nightly

### DIFF
--- a/.github/workflows/nightly-coraza.yml
+++ b/.github/workflows/nightly-coraza.yml
@@ -39,7 +39,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch last coraza version
-        run: go get -u github.com/corazawaf/coraza/v3@${{ steps.coraza-latest-commit.outputs.value }} && go mod tidy
+        run: go get github.com/corazawaf/coraza/v3@${{ steps.coraza-latest-commit.outputs.value }} && go mod tidy
 
       - name: Build caddy
         run: go run mage.go buildCaddyLinux


### PR DESCRIPTION
In https://github.com/corazawaf/coraza-caddy/pull/244, we have the `Nightly Coraza` job failing because we are checking the compatibility with upstream coraza, but we are also upgrading the Coraza dependencies.
I think that Nightly should ensure being compatible with latest Coraza commit, not with some changes that are not even yet merged into upstream, hence I'm proposing to remove the upgrade from the go get. 