### PR TITLE
fix(ci): use unique artifact names per matrix job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,5 +50,5 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
-          name: ftw-caddy-logs
+          name: ftw-caddy-logs-${{ matrix.go-version }}
           path: build/ftw-caddy.log


### PR DESCRIPTION
## Summary

- Append go version to the `ftw-caddy-logs` artifact name so each matrix job uploads with a unique name, fixing the 409 conflict error when the second job tries to upload.

## Test plan

- [ ] Verify both matrix jobs (go 1.25.x and 1.26.x) complete the upload-artifact step successfully.