### PR TITLE
fix: HTTP middleware to process all Transfer-Encoding values

### DIFF
--- a/http.go
+++ b/http.go
@@ -39,8 +39,10 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 	// Transfer-Encoding header is removed by go/http
 	// See https://github.com/golang/go/blob/ada0eec8277449ecd6383c86bc2e5fe7e7058fc7/src/net/http/transfer.go#L631
 	// We manually add it to make rules relying on it work (E.g. CRS rule 920171)
-	if req.TransferEncoding != nil {
-		tx.AddRequestHeader("Transfer-Encoding", req.TransferEncoding[0])
+	// All values must be added to allow the WAF to detect HTTP request smuggling
+	// attempts (e.g. TE.TE attacks).
+	for _, te := range req.TransferEncoding {
+		tx.AddRequestHeader("Transfer-Encoding", te)
 	}
 
 	in = tx.ProcessRequestHeaders()

--- a/http_test.go
+++ b/http_test.go
@@ -60,6 +60,25 @@ SecRule REQUEST_HEADERS:Transfer-Encoding "chunked" "id:100,phase:1,deny,status:
 	require.Equal(t, 403, it.Status)
 }
 
+func TestProcessRequestMultipleTransferEncodings(t *testing.T) {
+	// Multiple Transfer-Encoding values are a classic HTTP request smuggling vector (TE.TE attacks).
+	// All values should be forwarded to the WAF.
+	waf, _ := coraza.NewWAF(coraza.NewWAFConfig().
+		WithDirectives(`
+SecRule REQUEST_HEADERS:Transfer-Encoding "@contains identity" "id:1,phase:1,deny"
+`))
+	tx := waf.NewTransaction()
+
+	req, _ := http.NewRequest("GET", "https://www.coraza.io/test", nil)
+	req.TransferEncoding = []string{"chunked", "identity"}
+
+	it, err := processRequest(tx, req)
+	require.NoError(t, err)
+	require.NotNil(t, it, "Expected interruption: second Transfer-Encoding value should be processed")
+	require.Equal(t, 1, it.RuleID, "Expected rule 1 to be triggered")
+	require.NoError(t, tx.Close())
+}
+
 func TestParseServerName(t *testing.T) {
 	require.Equal(t, "www.example.com", parseServerName("www.example.com"))
 	require.Equal(t, "1.2.3.4", parseServerName("1.2.3.4:80"))


### PR DESCRIPTION
Ports https://github.com/corazawaf/coraza/pull/1518, address https://github.com/corazawaf/coraza/pull/1518#pullrequestreview-3902732396.
- change equal to coraza upstream middleware
- refactored the test to rely on require pkg used in this repo.