### PR TITLE
chore(ci): harden GHA workflows with least-privilege permissions

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions: {}
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest
@@ -10,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,17 +2,23 @@ name: "CodeQL"
 
 on:
   push:
-    branches: 
+    branches:
       - '*'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
   schedule:
     - cron: '0 6 * * 6'
+
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
 
     strategy:
       fail-fast: false
@@ -25,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -39,7 +45,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4
       with:
         languages: ${{ matrix.language }}
     - run: |
@@ -47,4 +53,4 @@ jobs:
        go mod vendor
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,17 +2,24 @@ name: Lint (pre-commit)
 
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
       - "main"
+
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
           go-version: 1.25.x
           cache: true

--- a/.github/workflows/nightly-caddy.yml
+++ b/.github/workflows/nightly-caddy.yml
@@ -11,6 +11,8 @@ on:
         description: "caddy version (branch, tag or commit)"
         required: true
 
+permissions: {}
+
 jobs:
   nightly-caddy:
     name: "Nightly Caddy (caddy version: ${{ github.event.inputs.caddyversion || 'master' }})"
@@ -20,14 +22,18 @@ jobs:
         os: [ubuntu-latest]
         xcaddy-version: [v0.3.5]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    env:
+      CADDY_VERSION: ${{ github.event.inputs.caddyversion || 'master' }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
         with:
           lfs: true
           fetch-depth: 0 #for better blame info
@@ -36,7 +42,7 @@ jobs:
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@${{ matrix.xcaddy-version }}
 
       - name: Build caddy
-        run: CADDY_VERSION=${{ github.event.inputs.caddyversion || 'master' }} go run mage.go buildCaddyLinux
+        run: CADDY_VERSION="${CADDY_VERSION}" go run mage.go buildCaddyLinux
 
       - name: Run e2e tests
         run: go run mage.go e2e

--- a/.github/workflows/nightly-coraza.yml
+++ b/.github/workflows/nightly-coraza.yml
@@ -6,6 +6,8 @@ on:
   schedule:
     - cron: "0 4 * * *"
 
+permissions: {}
+
 jobs:
   nightly-coraza:
     strategy:
@@ -14,14 +16,16 @@ jobs:
         os: [ubuntu-latest]
         xcaddy-version: [v0.4.5]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
         with:
           lfs: true
           fetch-depth: 0 #for better blame info

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,13 @@ on:
       - "**/*.md"
       - "LICENSE"
   pull_request:
+    branches:
+      - main
     paths-ignore:
       - "**/*.md"
       - "LICENSE"
+
+permissions: {}
 
 jobs:
   test:
@@ -20,14 +24,16 @@ jobs:
         os: [ubuntu-latest]
         xcaddy-version: [v0.4.5]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
         with:
           lfs: true
           fetch-depth: 0 #for better blame info
@@ -47,7 +53,7 @@ jobs:
       - name: Run regression tests (ftw)
         run: go run mage.go ftw
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: success() || failure()
         with:
           name: ftw-caddy-logs-${{ matrix.go-version }}


### PR DESCRIPTION
## Summary

Hardens all GitHub Actions workflows with security best practices.

| Workflow | Changes |
|---|---|
| **All workflows** | Added top-level `permissions: {}` (deny-all default) |
| **close-issues.yml** | Pinned `actions/stale` to SHA; kept existing job-level `issues: write` + `pull-requests: write` |
| **codeql-analysis.yml** | Pinned `actions/checkout`, `github/codeql-action/*` to SHA; added job-level `security-events: write` + `contents: read` |
| **lint.yml** | Pinned `actions/checkout`, `actions/setup-go` to SHA; added `branches: [main]` to `pull_request` trigger; added job-level `contents: read` |
| **nightly-caddy.yml** | Pinned `actions/setup-go`, `actions/checkout` to SHA; moved `caddyversion` input from inline expression to `env:` block to fix expression injection; added job-level `contents: read` |
| **nightly-coraza.yml** | Pinned `actions/setup-go`, `actions/checkout` to SHA; confirmed `GH_TOKEN` is set via `env:` block; added job-level `contents: read` |
| **tests.yml** | Pinned `actions/setup-go`, `actions/checkout`, `actions/upload-artifact` to SHA; added `branches: [main]` to `pull_request` trigger; added job-level `contents: read` |