### PR TITLE
fix(deps): update coraza to v3.6.0 — fix RelevantOnly audit logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/caddyserver/caddy/v2 v2.11.2
 	github.com/corazawaf/coraza-coreruleset/v4 v4.24.1
-	github.com/corazawaf/coraza/v3 v3.5.0
+	github.com/corazawaf/coraza/v3 v3.6.0
 	github.com/jcchavezs/mergefs v0.1.1
 	github.com/magefile/mage v1.17.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc h1:Ol
 github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc/go.mod h1:7rsocqNDkTCira5T0M7buoKR2ehh7YZiPkzxRuAgvVU=
 github.com/corazawaf/coraza-coreruleset/v4 v4.24.1 h1:O53krJaPFI7JCLA8JBPd9wgxJi7HJLYDE2I72h7WttE=
 github.com/corazawaf/coraza-coreruleset/v4 v4.24.1/go.mod h1:vRAP1vtdqSiJQzPuVhhtF7RusCRUYC9MCBl6nFj4C6E=
-github.com/corazawaf/coraza/v3 v3.5.0 h1:zGYW3cKhDa05Ztdt7+SGp7OkmR9AgxOFfLbDPwi0Y5M=
-github.com/corazawaf/coraza/v3 v3.5.0/go.mod h1:q7gszZCSufoHIy9jV2NCgk+glYwZpP2mIKgbu2dZkvE=
+github.com/corazawaf/coraza/v3 v3.6.0 h1:rfsGl6eRBzzUAyADFcpuO7qXLt0DZtYWhfTIuhcyAjQ=
+github.com/corazawaf/coraza/v3 v3.6.0/go.mod h1:q7gszZCSufoHIy9jV2NCgk+glYwZpP2mIKgbu2dZkvE=
 github.com/corazawaf/libinjection-go v0.3.2 h1:9rrKt0lpg4WvUXt+lwS06GywfqRXXsa/7JcOw5cQLwI=
 github.com/corazawaf/libinjection-go v0.3.2/go.mod h1:Ik/+w3UmTWH9yn366RgS9D95K3y7Atb5m/H/gXzzPCk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
## Summary
- Bumps `github.com/corazawaf/coraza/v3` from v3.5.0 to v3.6.0
- Picks up the fix for `SecAuditEngine RelevantOnly` not writing audit log files for blocked requests (corazawaf/coraza#1577)
- The root cause was that `ProcessLogging` required `tx.audit=true` (a rule with `log`/`auditlog` matched) before checking `SecAuditLogRelevantStatus`, using AND logic where the spec requires OR

Closes #284

## Test plan
- [x] All existing tests pass
- [ ] Verify with CRS Docker image that `RelevantOnly` now writes audit logs for blocked requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying security library dependency to the latest version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->