### PR TITLE
feat: expose JA4 TLS fingerprint to WAF rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,44 @@ go run mage.go buildCaddy
 curl -i localhost:8080/
 ```
 
+## JA4 TLS Fingerprinting
+
+When the [caddy-ja4](https://github.com/matt-/caddy-ja4) module is compiled into Caddy, the JA4 TLS fingerprint is automatically made available to Coraza rules as `TX:ja4_fingerprint`. This enables bot detection, client classification, and TLS-based blocking without any changes to the Coraza engine.
+
+### Build Caddy with both modules
+
+```shell
+xcaddy build --with github.com/corazawaf/coraza-caddy/v2 --with github.com/matt-/caddy-ja4
+```
+
+### Configure the listener wrapper
+
+The `ja4` listener wrapper must appear **before** the `tls` wrapper so it can observe the raw ClientHello:
+
+```caddy
+{
+    order coraza_waf first
+    servers {
+        listener_wrappers {
+            ja4
+            tls
+        }
+    }
+}
+```
+
+### Write rules using TX:ja4_fingerprint
+
+```
+SecRule TX:ja4_fingerprint "@streq t13d1517h2_8daaf6152771_b6f405a00624" \
+    "id:100,phase:1,deny,log,msg:'Blocked JA4 fingerprint'"
+
+SecRule TX:ja4_fingerprint "@rx ^t13d1517h2_" \
+    "id:101,phase:1,deny,log,msg:'Blocked JA4 fingerprint prefix'"
+```
+
+If caddy-ja4 is not compiled in or the request lacks a TLS handshake (e.g. plaintext HTTP), `TX:ja4_fingerprint` is simply not set and the rules are skipped.
+
 ## Respond with custom message or HTML page
 
 In order to respond with a custom message or HTML page, you can take advantage of [handle_errors](https://caddyserver.com/docs/caddyfile/directives/handle_errors) directive:

--- a/coraza.go
+++ b/coraza.go
@@ -19,6 +19,7 @@ import (
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	coreruleset "github.com/corazawaf/coraza-coreruleset/v4"
 	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/jcchavezs/mergefs"
 	mergefsio "github.com/jcchavezs/mergefs/io"
@@ -190,6 +191,15 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 	repl.Set("http.transaction_id", id)
+
+	// Populate TX:ja4_fingerprint from caddy-ja4 module if available.
+	// This allows rules to match on the JA4 TLS fingerprint, e.g.:
+	//   SecRule TX:ja4_fingerprint "@streq t13d..." "id:100,phase:1,deny"
+	if ja4, ok := caddyhttp.GetVar(r.Context(), "ja4").(string); ok && ja4 != "" {
+		if ts, ok := tx.(plugintypes.TransactionState); ok {
+			ts.Variables().TX().Set("ja4_fingerprint", []string{ja4})
+		}
+	}
 
 	// ProcessRequest is just a wrapper around ProcessConnection, ProcessURI,
 	// ProcessRequestHeaders and ProcessRequestBody.

--- a/coraza_test.go
+++ b/coraza_test.go
@@ -731,3 +731,73 @@ func TestServeHTTP_txCloseErrorIsLogged(t *testing.T) {
 	require.NotEmpty(t, entry.ContextMap()["tx_id"], "tx_id field must be present")
 	require.Equal(t, closeErr.Error(), entry.ContextMap()["error"], "error field must match")
 }
+
+// TestServeHTTP_JA4FingerprintSetInTX verifies that when the ja4 context
+// variable is present (as set by the caddy-ja4 listener wrapper), it is
+// propagated to TX:ja4_fingerprint so SecRules can match on it.
+func TestServeHTTP_JA4FingerprintSetInTX(t *testing.T) {
+	const testJA4 = "t13d1517h2_8daaf6152771_b6f405a00624"
+
+	tests := []struct {
+		name               string
+		ja4                string
+		expectedStatusCode int
+	}{
+		{
+			name:               "JA4 present triggers matching rule",
+			ja4:                testJA4,
+			expectedStatusCode: http.StatusForbidden,
+		},
+		{
+			name:               "JA4 absent skips rule",
+			ja4:                "",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "non-matching JA4 skips rule",
+			ja4:                "t13d0000h2_0000000000_000000000000",
+			expectedStatusCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			waf, err := corazaWAF.NewWAF(
+				corazaWAF.NewWAFConfig().WithDirectives(fmt.Sprintf(
+					`SecRuleEngine On
+					SecRule TX:ja4_fingerprint "@streq %s" "id:100,phase:1,deny,status:403"`, testJA4)),
+			)
+			require.NoError(t, err)
+
+			m := corazaModule{
+				waf:    waf,
+				logger: zap.NewNop(),
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = "127.0.0.1:12345"
+
+			// Build context with replacer and vars as Caddy's PrepareRequest would.
+			ctx := context.WithValue(req.Context(), caddy.ReplacerCtxKey, caddy.NewReplacer())
+			vars := map[string]any{}
+			if tt.ja4 != "" {
+				vars["ja4"] = tt.ja4
+			}
+			ctx = context.WithValue(ctx, caddyhttp.VarsCtxKey, vars)
+			req = req.WithContext(ctx)
+
+			w := httptest.NewRecorder()
+			noopHandler := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error { return nil })
+
+			err = m.ServeHTTP(w, req, noopHandler)
+
+			if tt.expectedStatusCode == http.StatusOK {
+				require.NoError(t, err)
+			} else {
+				var handlerErr caddyhttp.HandlerError
+				require.ErrorAs(t, err, &handlerErr)
+				require.Equal(t, tt.expectedStatusCode, handlerErr.StatusCode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- When [caddy-ja4](https://github.com/matt-/caddy-ja4) is compiled into Caddy, reads the JA4 fingerprint from the request context and sets it as `TX:ja4_fingerprint` before rule evaluation
- Enables TLS-based bot detection and client classification in SecRules without changes to the Coraza engine
- Documents build instructions, listener wrapper config, and example rules in the README

## How it works
The JA4 fingerprint is read via `caddyhttp.GetVar(r.Context(), "ja4")` and written to the TX collection through the experimental `plugintypes.TransactionState` interface. If caddy-ja4 is not compiled in or the fingerprint is empty, the code is a no-op.

Example rule usage:
```
SecRule TX:ja4_fingerprint "@streq t13d1517h2_8daaf6152771_b6f405a00624" \
    "id:100,phase:1,deny,log,msg:'Blocked JA4 fingerprint'"
```

## Test plan
- [x] All 107 existing tests pass
- [ ] Build with `xcaddy build --with github.com/corazawaf/coraza-caddy/v2 --with github.com/matt-/caddy-ja4` and verify JA4 fingerprint appears in TX collection
- [ ] Verify rules matching on `TX:ja4_fingerprint` trigger correctly with a known fingerprint
- [ ] Verify no-op behavior when caddy-ja4 is not compiled in (current test suite covers this implicitly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for JA4 TLS fingerprinting integration with Coraza rules.
  * JA4 fingerprint values can now be referenced and evaluated in rule configurations.

* **Documentation**
  * Added comprehensive guide for building and configuring Caddy with JA4 fingerprinting support.
  * Documented conditional behavior when JA4 module is unavailable.

* **Tests**
  * Added test coverage for JA4 fingerprint functionality in rule evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->