### PR TITLE
feat: expand caddy placeholders

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -1,0 +1,60 @@
+package coraza
+
+import (
+	"context"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/types"
+)
+
+const (
+	caddyPlaceholdersExpandGlobalName = "global"
+	caddyPlaceholderCollectionName    = "CADDY"
+)
+
+func (m corazaModule) injectCaddyValues(ctx context.Context, tx types.Transaction) {
+	state, ok := tx.(plugintypes.TransactionState)
+	if !ok {
+		return
+	}
+
+	repl, ok := ctx.Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	if !ok {
+		return
+	}
+
+	for _, key := range m.CaddyVars {
+		if key == caddyPlaceholdersExpandGlobalName {
+			continue
+		}
+
+		if val, ok := repl.GetString(key); ok {
+			state.Variables().TX().Add(caddyPlaceholderCollectionName+"."+key, val)
+		}
+	}
+}
+
+// processCaddyPlaceholders expand global Caddy placeholders if caddyPlaceholdersExpandGlobalName used
+// and prepare Coraza macroses for placeholders which can be expanded only in runtime.
+func (m *corazaModule) processCaddyPlaceholders() {
+	if len(m.CaddyVars) == 0 {
+		return
+	}
+
+	runtimeRepl := caddy.NewEmptyReplacer()
+	repl := runtimeRepl
+	for _, key := range m.CaddyVars {
+		if key == caddyPlaceholdersExpandGlobalName {
+			repl = caddy.NewReplacer()
+			repl.Map(func(key string) (any, bool) {
+				return runtimeRepl.Get(key)
+			})
+		}
+
+		// replace Caddy placeholder with Coraza macros to resolve it's value in runtime
+		runtimeRepl.Set(key, "%{TX."+caddyPlaceholderCollectionName+"."+key+"}")
+	}
+
+	m.Directives = repl.ReplaceKnown(m.Directives, "")
+}

--- a/coraza.go
+++ b/coraza.go
@@ -19,6 +19,7 @@ import (
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	coreruleset "github.com/corazawaf/coraza-coreruleset/v4"
 	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/experimental"
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/jcchavezs/mergefs"
 	mergefsio "github.com/jcchavezs/mergefs/io"
@@ -61,9 +62,10 @@ type corazaModule struct {
 	Directives   string   `json:"directives"`
 	LoadOWASPCRS bool     `json:"load_owasp_crs"`
 
-	logger  *zap.Logger
-	waf     coraza.WAF
-	poolKey string
+	CaddyVars []string `json:"caddy_vars,omitempty"`
+	logger    *zap.Logger
+	waf       coraza.WAF
+	poolKey   string
 }
 
 // CaddyModule returns the Caddy module information.
@@ -172,8 +174,7 @@ var errInterruptionTriggered = errors.New("interruption triggered")
 
 // ServeHTTP implements caddyhttp.MiddlewareHandler.
 func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
-	id := randomString(16)
-	tx := m.waf.NewTransactionWithID(id)
+	tx := m.newTX(r)
 	defer func() {
 		tx.ProcessLogging()
 		if err := tx.Close(); err != nil {
@@ -189,10 +190,12 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	}
 
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
-	repl.Set("http.transaction_id", id)
+	repl.Set("http.transaction_id", tx.ID())
 
 	server := r.Context().Value(caddyhttp.ServerCtxKey).(*caddyhttp.Server)
 	caddyhttp.PrepareRequest(r, repl, w, server)
+
+	m.injectCaddyValues(r.Context(), tx)
 
 	// ProcessRequest is just a wrapper around ProcessConnection, ProcessURI,
 	// ProcessRequestHeaders and ProcessRequestBody.
@@ -241,6 +244,15 @@ func (m *corazaModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				return d.ArgErr()
 			}
 			m.LoadOWASPCRS = true
+		case "expand_caddy_placeholders":
+			m.CaddyVars = d.RemainingArgs()
+			if len(m.CaddyVars) == 0 {
+				return d.ArgErr()
+			}
+			repl := caddy.NewReplacer()
+			for i := range m.CaddyVars {
+				m.CaddyVars[i] = repl.ReplaceAll(m.CaddyVars[i], "")
+			}
 		case "directives", "include":
 			var value string
 			if !d.Args(&value) {
@@ -264,7 +276,22 @@ func (m *corazaModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		}
 	}
 
+	m.processCaddyPlaceholders()
+
 	return nil
+}
+
+func (m *corazaModule) newTX(r *http.Request) types.Transaction {
+	id := randomString(16)
+
+	if ctxwaf, ok := m.waf.(experimental.WAFWithOptions); ok {
+		return ctxwaf.NewTransactionWithOptions(experimental.Options{
+			ID:      id,
+			Context: r.Context(),
+		})
+	}
+
+	return m.waf.NewTransactionWithID(id)
 }
 
 // parseCaddyfile unmarshals tokens from h into a new Middleware.

--- a/coraza_test.go
+++ b/coraza_test.go
@@ -668,6 +668,133 @@ func TestResponseBody(t *testing.T) {
 	}
 }
 
+func TestCaddyPlaceholders(t *testing.T) {
+	hostname, err := os.Hostname()
+	require.NoError(t, err)
+
+	filePlaceholderPath := filepath.Join(t.TempDir(), "header.txt")
+	require.NoError(t, os.WriteFile(filePlaceholderPath, []byte(`X-Test`), 0o644))
+
+	testCases := []struct {
+		name               string
+		headers            http.Header
+		placeholders       []string
+		config             string
+		expectedStatusCode int
+	}{
+		{
+			name:         "GlobalPlaceholder",
+			placeholders: []string{`"global"`},
+			config: fmt.Sprintf(`
+						SecAction "id:100,nolog,phase:1,setvar:tx.hostname={system.hostname}"
+
+						SecRule TX:hostname "@streq %s" "id:101,phase:1,deny,t:none,status:299,chain"`, hostname),
+			expectedStatusCode: 299,
+		},
+		{
+			name:         "RunimePlaceholder",
+			placeholders: []string{`"http.request.header.X-Test"`},
+			config: `
+						SecAction "id:100,nolog,phase:1,setvar:tx.test_header={http.request.header.X-Test}"
+
+						SecRule TX:test_header "@streq test123" "id:101,phase:1,deny,t:none,status:299"`,
+			headers:            http.Header{"X-Test": {"test123"}},
+			expectedStatusCode: 299,
+		},
+		{
+			name:         "MultiByNameFromFile",
+			placeholders: []string{fmt.Sprintf(`"http.request.header.{file.%s}"`, filePlaceholderPath), "global"},
+			config: fmt.Sprintf(`
+						SecAction "id:100,nolog,phase:1,\
+							setvar:tx.hostname={system.hostname},\
+							setvar:tx.test_header={http.request.header.X-Test}"
+
+						SecRule TX:hostname "@streq %s" "id:101,phase:1,deny,t:none,status:299,chain"
+								SecRule TX:test_header "@streq test123" "t:none"`, hostname),
+			headers:            http.Header{"X-Test": {"test123"}},
+			expectedStatusCode: 299,
+		},
+		{
+			name:         "MissedValue",
+			placeholders: []string{`"http.request.header.X-Test"`},
+			config: `
+						SecAction "id:100,nolog,phase:1,setvar:tx.test_header={http.request.header.X-Test}"
+
+						SecRule TX:test_header "@eq 0" "id:101,phase:1,deny,t:none,t:length,status:299"`,
+			expectedStatusCode: 299,
+		},
+		{
+			name:         "NoConflictCurlyBrackets",
+			placeholders: []string{`"global"`},
+			config: `
+						SecRule &TX:critical_anomaly_score "@eq 0" \
+							"id:901140,\
+							phase:1,\
+							pass,\
+							nolog,\
+							tag:'OWASP_CRS',\
+							ver:'OWASP_CRS/4.25.0',\
+							setvar:'tx.critical_anomaly_score=5'"
+
+						SecRule REQUEST_HEADERS:Accept "!@rx ^(?:(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)/(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)|\*)(?:[\s\x0b]*;[\s\x0b]*(?:charset[\s\x0b]*=[\s\x0b]*\"?(?:iso-8859-15?|utf-8|windows-1252)\b\"?|(?:[^\s\x0b-\"\(\),/:-\?\[-\]c\{\}]|c(?:[^!\"\(\),/:-\?\[-\]h\{\}]|h(?:[^!\"\(\),/:-\?\[-\]a\{\}]|a(?:[^!\"\(\),/:-\?\[-\]r\{\}]|r(?:[^!\"\(\),/:-\?\[-\]s\{\}]|s(?:[^!\"\(\),/:-\?\[-\]e\{\}]|e[^!\"\(\),/:-\?\[-\]t\{\}]))))))[^!\"\(\),/:-\?\[-\]\{\}]*[\s\x0b]*=[\s\x0b]*[^!\(\),/:-\?\[-\]\{\}]+);?)*(?:[\s\x0b]*,[\s\x0b]*(?:(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)/(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)|\*)(?:[\s\x0b]*;[\s\x0b]*(?:charset[\s\x0b]*=[\s\x0b]*\"?(?:iso-8859-15?|utf-8|windows-1252)\b\"?|(?:[^\s\x0b-\"\(\),/:-\?\[-\]c\{\}]|c(?:[^!\"\(\),/:-\?\[-\]h\{\}]|h(?:[^!\"\(\),/:-\?\[-\]a\{\}]|a(?:[^!\"\(\),/:-\?\[-\]r\{\}]|r(?:[^!\"\(\),/:-\?\[-\]s\{\}]|s(?:[^!\"\(\),/:-\?\[-\]e\{\}]|e[^!\"\(\),/:-\?\[-\]t\{\}]))))))[^!\"\(\),/:-\?\[-\]\{\}]*[\s\x0b]*=[\s\x0b]*[^!\(\),/:-\?\[-\]\{\}]+);?)*)*$" \
+							"id:920600,\
+							phase:1,\
+							block,\
+							t:none,t:lowercase,\
+							msg:'Illegal Accept header: charset parameter',\
+							logdata:'%{MATCHED_VAR}',\
+							tag:'application-multi',\
+							tag:'language-multi',\
+							tag:'platform-multi',\
+							tag:'attack-protocol',\
+							tag:'paranoia-level/1',\
+							tag:'OWASP_CRS',\
+							tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
+							ver:'OWASP_CRS/4.25.0',\
+							severity:'CRITICAL',\
+							setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+						SecRule TX:inbound_anomaly_score_pl1 "@eq 5" "id:100,deny,nolog,phase:1,status:299"`,
+			headers:            http.Header{"Accept": {"text/html;q=0.9;charset=CP1026,*/*;q=0.8"}},
+			expectedStatusCode: 299,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tester := caddytest.NewTester(t)
+			config := fmt.Sprintf(`{
+				debug
+				admin localhost:%d
+				auto_https off
+				order coraza_waf first
+			}
+
+			:8080 {
+				coraza_waf {
+					expand_caddy_placeholders %s
+					directives <<CORAZA
+						SecRuleEngine On
+
+						%s
+					CORAZA
+				}
+
+				respond 204
+			}`, caddytest.Default.AdminPort, strings.Join(testCase.placeholders, " "), testCase.config)
+			tester.InitServer(config, "caddyfile")
+
+			req, err := http.NewRequest(http.MethodGet, baseURL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header = testCase.headers
+
+			tester.AssertResponseCode(req, testCase.expectedStatusCode)
+		})
+	}
+}
+
 // txCloseErrWrapper wraps a real Coraza transaction and overrides Close to
 // return a configurable error. This lets tests verify that ServeHTTP logs a
 // warning when tx.Close() fails, without needing to reach into Coraza internals.


### PR DESCRIPTION
## Summary
Support of Caddy [placeholders](https://caddyserver.com/docs/conventions#placeholders) expand for `coraza_waf` directive.
Supported placeholders:
- [x] Caddy global (e.g. `env.*`, `file.*`)
- [x] request scoped (e.g. `http.request.header.*`)
- [x] third-party plugins provided (e.g. `geoip2.country_code`)

Expanded value can be assigned through `setvar` action to Coraza variable, which could be used for `SecRule` or as macros.
Only selected placeholders will be processed to prevent conflicts with other Coraza config primitives with curly braces, such as macroses or regexps.
To activate processing `expand_caddy_placeholders` directive should be specified with at least one placeholder. Reserved value `global` is for all at once Caddy global placeholders, which expand only once on config parse step.

## Example
```
{
	admin off
	auto_https off
	order coraza_waf first
}

:8080 {
	coraza_waf {
		expand_caddy_placeholders global "http.request.header.X-Test"
		directives <<CORAZA
			SecRuleEngine On

			SecAction "id:100,nolog,phase:1,\
				setvar:tx.hostname={system.hostname},\
				setvar:tx.test_header={http.request.header.X-Test}"

			SecRule TX:hostname "@streq Users-MacBook-Pro.local" "id:101,phase:1,deny,t:none,chain"
				SecRule TX:test_header "@streq test123" "t:none"
		CORAZA
	}

	respond 204
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for expanding Caddy placeholders inside WAF directives using configurable “caddy vars”.
  * Placeholders can now be sourced from globals, incoming request headers, and values derived from files.
  * Improved request handling by enhancing transaction initialization and placeholder resolution during WAF processing.
* **Tests**
  * Added end-to-end coverage for placeholder expansion, including global/request/file cases and edge-case behavior to avoid curly-bracket conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->