### PR TITLE
Fix client_ip in logger http.handlers.waf

### DIFF
--- a/coraza.go
+++ b/coraza.go
@@ -204,10 +204,11 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 			Err:        err,
 		}
 	} else if it != nil {
+		client, _ := getClientAddress(r)
 		m.logger.Error("WAF rule violation detected",
 			zap.String("hostname", r.Host),
 			zap.String("uri", r.RequestURI),
-			zap.String("client_ip", r.RemoteAddr),
+			zap.String("client_ip", client),
 			zap.String("unique_id", tx.ID()),
 		)
 		return caddyhttp.HandlerError{


### PR DESCRIPTION
In addition to the pull request https://github.com/corazawaf/coraza-caddy/pull/184/changes for setting the correct client_ip IP via getClientAddress, the generation of the error log with the correct IP has been left out of the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed client IP address capture in WAF rule violation logs to ensure accurate security event reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/corazawaf/coraza-caddy/pull/306)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->