### PR TITLE
fix: keep WebSocket upgrades working when Hijack is reachable only via Unwrap

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -50,6 +50,15 @@ func (i *rwInterceptor) WriteHeader(statusCode int) {
 	}
 
 	i.wroteHeader = true
+
+	// 101 Switching Protocols must reach the client before the connection
+	// is hijacked for bidirectional streaming (e.g. a WebSocket upgrade):
+	// there is no response body to inspect, and keeping the status buffered
+	// would leave the upgrade response unsent once the connection has been
+	// hijacked, so the client would hang waiting for the status line.
+	if statusCode == http.StatusSwitchingProtocols {
+		i.flushWriteHeader()
+	}
 }
 
 // overrideWriteHeader overrides the recorded status code
@@ -132,6 +141,18 @@ func (i *rwInterceptor) Header() http.Header {
 	return i.w.Header()
 }
 
+// Unwrap returns the underlying ResponseWriter so http.ResponseController
+// can reach capabilities implemented deeper in the wrapper chain. Notably,
+// Caddy's own response writer wrappers (installed e.g. when access logging
+// is enabled) do not have a Hijack method at all — they expose hijacking
+// only through Unwrap — so the type assertions in wrap() cannot see it.
+// Without Unwrap here the chain is severed at the interceptor and every
+// WebSocket upgrade fails with "can't switch protocols using non-Hijacker
+// ResponseWriter" (see corazawaf/coraza-caddy#78).
+func (i *rwInterceptor) Unwrap() http.ResponseWriter {
+	return i.w
+}
+
 func (i *rwInterceptor) ReadFrom(r io.Reader) (n int64, err error) {
 	return io.Copy(struct{ io.Writer }{i}, r)
 }
@@ -193,6 +214,10 @@ type responseWriter interface {
 	http.ResponseWriter
 	io.ReaderFrom
 	http.Flusher
+	// Unwrap is part of the http.ResponseController convention; exposing it
+	// through every wrapper combination returned by wrap() keeps the chain
+	// walkable so capabilities like Hijack remain reachable.
+	Unwrap() http.ResponseWriter
 }
 
 var _ responseWriter = (*rwInterceptor)(nil)

--- a/interceptor_websocket_test.go
+++ b/interceptor_websocket_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression tests for corazawaf/coraza-caddy#78: WebSocket upgrades must
+// survive the interceptor when the underlying writer chain exposes Hijack
+// only via Unwrap, as Caddy's own response writer wrappers do (installed
+// e.g. when access logging is enabled).
+
+package coraza
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// hijackableRecorder mimics the innermost HTTP/1.1 ResponseWriter: it
+// implements http.Hijacker directly.
+type hijackableRecorder struct {
+	*httptest.ResponseRecorder
+	hijacked bool
+}
+
+func (r *hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	r.hijacked = true
+	c1, _ := net.Pipe()
+	return c1, bufio.NewReadWriter(bufio.NewReader(c1), bufio.NewWriter(c1)), nil
+}
+
+// caddyStyleWrapper mimics caddyhttp.ResponseWriterWrapper: it always has a
+// Push method, never a Hijack method, and exposes the inner writer only via
+// Unwrap (the http.ResponseController convention).
+type caddyStyleWrapper struct {
+	http.ResponseWriter
+}
+
+func (w caddyStyleWrapper) Push(target string, opts *http.PushOptions) error {
+	return http.ErrNotSupported
+}
+
+func (w caddyStyleWrapper) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func TestHijackThroughUnwrapOnlyWrapper(t *testing.T) {
+	tx := newTestTransaction(t)
+	defer tx.Close()
+
+	inner := &hijackableRecorder{ResponseRecorder: httptest.NewRecorder()}
+	outer := caddyStyleWrapper{ResponseWriter: inner}
+
+	// Sanity: the wrapped writer matches the shape seen in production —
+	// Pusher via method set, Hijacker reachable only through Unwrap.
+	_, isHijacker := interface{}(outer).(http.Hijacker)
+	require.False(t, isHijacker)
+	_, isPusher := interface{}(outer).(http.Pusher)
+	require.True(t, isPusher)
+
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	ww, _ := wrap(outer, req, tx)
+
+	// The reverse proxy hijacks via http.ResponseController, which walks
+	// the Unwrap chain. Without Unwrap on the interceptor this fails with
+	// http.ErrNotSupported.
+	_, _, err := http.NewResponseController(ww).Hijack()
+	require.NoError(t, err)
+	require.True(t, inner.hijacked)
+}
+
+func TestWriteHeader101FlushedImmediately(t *testing.T) {
+	tx := newTestTransaction(t)
+	defer tx.Close()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	ww, _ := wrap(rec, req, tx)
+
+	// 101 must reach the underlying writer before any hijack happens;
+	// buffering it would strand the client waiting for the status line.
+	ww.WriteHeader(http.StatusSwitchingProtocols)
+	require.Equal(t, http.StatusSwitchingProtocols, rec.Code)
+}
+
+func TestWriteHeaderNon101StillBuffered(t *testing.T) {
+	tx := newTestTransaction(t)
+	defer tx.Close()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	ww, _ := wrap(rec, req, tx)
+
+	// Regular statuses keep the existing behaviour: recorded but not yet
+	// flushed, so a later phase-4 interruption can still override them.
+	ww.WriteHeader(http.StatusTeapot)
+	require.Equal(t, http.StatusOK, rec.Code) // recorder default — nothing flushed yet
+}


### PR DESCRIPTION
When Caddy wraps the ResponseWriter (e.g. whenever access logging is enabled), the wrapper has no Hijack method at all: hijacking is exposed only through Unwrap() for http.ResponseController to discover. The type assertions in wrap() therefore see a writer that is a Pusher but not a Hijacker, return the {responseWriter; Pusher} combination, and — because none of the combinations implement Unwrap — sever the unwrap chain. The reverse proxy's ResponseController.Hijack() then fails with "can't switch protocols using non-Hijacker ResponseWriter", breaking every WebSocket upgrade as soon as Coraza is active (#78).

Two changes:

1. Implement Unwrap() on rwInterceptor and expose it through every wrapper combination, so ResponseController can keep walking the chain to reach Hijack (and other capabilities) implemented deeper down.

2. Flush the response header immediately on WriteHeader(101). A 101 response has no inspectable body, and the client must receive the status line before the connection is hijacked for bidirectional streaming; keeping it buffered would leave the upgrade response unsent after a successful hijack, hanging the client.

Verified end-to-end against a Caddy build with access logging enabled: before, every WS upgrade logged the non-Hijacker error and clients reconnect-stormed; after, upgrades complete (101 + bidirectional frames) while request inspection (e.g. CRS blocking on the handshake URI/query) keeps working.

Fixes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket connections now establish correctly when response writers are wrapped.
  * HTTP 101 Switching Protocols responses are flushed immediately.
  * Existing buffering behavior for other response statuses remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->