### PR TITLE
chore: extend the shared corazawaf renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    ":dependencyDashboard",
-    ":semanticPrefixFixDepsChoreOthers",
-    ":ignoreModulesAndTests",
-    "group:monorepos",
-    "group:recommended",
-    "replacements:all",
-    "workarounds:all"
+    "github>corazawaf/renovate-config"
   ],
-  "constraints": {
-    "go": "1.23"
-  },
   "postUpdateOptions": [
     "gomodTidy"
   ]


### PR DESCRIPTION
`coraza-caddy` maintained its own hand-rolled preset list, while [`corazawaf/coraza`](https://github.com/corazawaf/coraza/blob/main/renovate.json) and [`corazawaf/coraza-spoa`](https://github.com/corazawaf/coraza-spoa/blob/main/renovate.json) both extend `github>corazawaf/renovate-config`. This brings coraza-caddy in line.

### Why

The shared config carries a package rule this repo was missing:

```json
{
  "groupName": "docker golang major release",
  "matchDatasources": ["docker", "golang-version"],
  "matchPackageNames": ["go", "golang"],
  "allowedVersions": "~1.25.0"
}
```

#265 (`go-version: 1.25.x` -> `1.27.x` in `lint.yml`) reports `Package: go`, `Type: uses-with`, sourced from `actions/go-versions` — Renovate's `golang-version` datasource, which that rule matches. With no such rule locally, nothing bounded the version and Renovate offered the newest stable.

Adopting the shared config also picks up `minimumReleaseAge: 15 days`, `config:best-practices`, daily scheduling, the shared label/security presets, and automerge for github-actions and non-major deps.

### Also

Drops `constraints.go`, which was pinned at `1.23` while `go.mod` is on `1.25.1`. Renovate infers it from `go.mod` when unset, which is what the sibling repos do.

Keeps `postUpdateOptions: [gomodTidy]`.

Validated with `renovate-config-validator`:

```console
$ npx --package renovate -- renovate-config-validator
 INFO: Validating renovate.json
 INFO: Config validated successfully against 1 file(s)
```

### Expected effect on #265

`~1.25.0` means `>=1.25.0 <1.26.0`, so Renovate should close #265 rather than retarget it. Worth flagging that this leaves `lint.yml` on 1.25.x while `tests.yml` runs a `[1.25.x, 1.26.x]` matrix — the org cap looks stale rather than deliberate, and raising it to `~1.26.0` in `corazawaf/renovate-config` would be a separate cross-repo change.

### Unrelated, noticed while reading

`package-rules.json` in the org config lists `"postUpdateOptions": ["gomodUpdateImportPaths", "goModTidy"]`. The documented option is `gomodTidy` (lowercase `mod`), so `goModTidy` may be silently ignored. Not changed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update configuration to use the shared Renovate preset.
  * Preserved automatic Go module tidying after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->