### PR TITLE
ci: read the lint Go version from go.mod

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: 1.25.x
+          go-version-file: go.mod
           cache: true
 
       - run: go run mage.go lint


### PR DESCRIPTION
Replaces the hardcoded `go-version: 1.25.x` in `lint.yml` with `go-version-file: go.mod`.

## Why only lint.yml

I ran Renovate's own github-actions extractor over all four workflows:

| workflow | extracted `currentValue` | updatable |
|---|---|---|
| `lint.yml` | `"1.25.x"` | yes |
| `tests.yml` | `"${{ matrix.go-version }}"` | no |
| `nightly-caddy.yml` | `"${{ matrix.go-version }}"` | no |
| `nightly-coraza.yml` | `"${{ matrix.go-version }}"` | no |

The matrices extract as the literal template string, so Renovate has never been able to resolve or bump them — `lint.yml` was the only Go version under management here, which is why #265 only ever proposed changing that one file.

The matrices stay hand-maintained deliberately. Automating them would need a custom regex manager, and Renovate bumps every match to the newest allowed version, so `[1.25.x, 1.26.x]` would collapse to `[1.26.x, 1.26.x]` under the `~1.26.0` cap — losing the second version the matrix exists to test.

## What this changes in practice

The version moves from the github-actions manager to the gomod manager, which extracts it as:

```
depName=go datasource=golang-version depType=golang currentValue=1.25.1
```

matched by the shared preset's `matchManagers: [gomod], matchDepNames: [go]` rule and capped at `~1.26.0`.

`setup-go` treats a patch-qualified `go` directive as an **exact** version ([`installer.ts`](https://github.com/actions/setup-go/blob/main/src/installer.ts) `parseGoVersionFile` returns it verbatim), so lint runs 1.25.1 rather than the latest 1.25.x:

```
1.25.7 satisfies "1.25.1": false
1.25.7 satisfies "1.25.x": true
```

That is the behaviour I want for a lint job — it checks against the minimum version we claim to support, and it can no longer race ahead of the toolchain golangci-lint handles, which is exactly what broke #265 (`export data version 4 is greater than maximum supported version 2` on Go 1.27).

## What I tried and backed out

Relaxing the directive to `go 1.25` so it would resolve to the latest patch. Not possible — `caddyserver/caddy/v2` and `go.step.sm/crypto` both require 1.25.1, and `go mod tidy` restores it:

```console
$ go list -m -f '{{.Path}} {{.GoVersion}}' all | sort -V -r | head -3
1.25.1 go.step.sm/crypto
1.25.1 github.com/corazawaf/coraza-caddy/v2
1.25.1 github.com/caddyserver/caddy/v2
```

So `go.mod` is untouched; this is a one-line change.

```console
$ actionlint .github/workflows/lint.yml   # clean
$ go build ./...                          # BUILD OK
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the lint workflow to automatically use the Go version specified by the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->