### PR TITLE
docs: explain embedded CRS loading and debug log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ resolvable. This has two consequences:
 
 If you use an `@` path without `load_owasp_crs`, Caddy fails at startup with:
 
-```
+```text
 invalid WAF config from string: failed to readfile:
   open @coraza.conf-recommended: no such file or directory
 ```

--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ most when one Caddy process serves many sites that each load CRS.
 | *(none)* | Memoization enabled (default) |
 | `coraza.no_memoize` | Disabled — every pattern compiles fresh |
 
+Older guidance recommends building with `-tags memoize_builders`. That tag was
+how memoization was opted into up to Coraza v3.4.0, when the default was off. It
+was removed in v3.5.0 once memoization became the default. Go ignores unknown
+build tags silently, so passing it today neither fails nor does anything — drop
+it from your build.
+
 The cache is global to the process, so entries are released when a WAF is
 destroyed. This module already does that: the pooled WAF is closed through
 `caddy.Destructor` when the last reference is released, which is what lets

--- a/README.md
+++ b/README.md
@@ -94,6 +94,26 @@ go run mage.go test
 
 You can load OWASP CRS by passing the field `load_owasp_crs` and then load the CRS files in the directives as described in the [coraza-coreruleset](https://github.com/corazawaf/coraza-coreruleset) documentation.
 
+The `@`-prefixed paths are **not files on disk**. They are served from a ruleset
+that is compiled into the binary, and `load_owasp_crs` is what makes them
+resolvable. This has two consequences:
+
+- You do not need to download CRS, mount a volume, or ship rule files alongside
+  the binary. `xcaddy build --with github.com/corazawaf/coraza-caddy/v2` already
+  contains them.
+- Do not put a filesystem path in front of an `@` path.
+  `Include /etc/caddy/rules/@owasp_crs/*.conf` will not work; the `@` prefix
+  must start the path.
+
+If you use an `@` path without `load_owasp_crs`, Caddy fails at startup with:
+
+```
+invalid WAF config from string: failed to readfile:
+  open @coraza.conf-recommended: no such file or directory
+```
+
+Adding `load_owasp_crs` to the `coraza_waf` block resolves it.
+
 ```caddy
 :8080 {
  coraza_waf {
@@ -133,6 +153,27 @@ This is useful when running coraza behind another HTTP server and using the requ
  reverse_proxy httpbin:8081
 }
 ```
+
+
+## Performance
+
+Coraza memoizes the expensive parts of rule compilation (regex and
+aho-corasick pattern compilation) so identical patterns are not recompiled when
+several WAF instances in the same process share the same rules. This matters
+most when one Caddy process serves many sites that each load CRS.
+
+**Memoization is enabled by default.** There is no flag to turn it on. The
+`coraza.no_memoize` build tag exists only to turn it *off*:
+
+| Build tag | Behaviour |
+|---|---|
+| *(none)* | Memoization enabled (default) |
+| `coraza.no_memoize` | Disabled — every pattern compiles fresh |
+
+The cache is global to the process, so entries are released when a WAF is
+destroyed. This module already does that: the pooled WAF is closed through
+`caddy.Destructor` when the last reference is released, which is what lets
+memory be reclaimed across config reloads.
 
 
 ## Running Example

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -34,3 +34,42 @@ If you need to harden against HPACK bomb-style traffic, configure limits on the 
 Note the Caddyfile option is `max_header_size`; `max_header_bytes` is the corresponding key in Caddy's JSON config, and using that name in a Caddyfile is a parse error.
 
 Use a value appropriate for your application. Lower values improve resilience to oversized/expanded headers, but may block legitimate requests with large cookies or header sets.
+
+### `open @coraza.conf-recommended: no such file or directory`
+The `@`-prefixed CRS paths are served from a ruleset compiled into the binary, not read from disk, and the `load_owasp_crs` field is what makes them resolvable. Without it Caddy treats `@coraza.conf-recommended` as a literal filename and fails at startup:
+
+```
+invalid WAF config from string: failed to readfile:
+  open @coraza.conf-recommended: no such file or directory
+```
+
+Add `load_owasp_crs` to the `coraza_waf` block:
+
+```caddy
+coraza_waf {
+	load_owasp_crs
+	directives `
+	Include @coraza.conf-recommended
+	Include @crs-setup.conf.example
+	Include @owasp_crs/*.conf
+	SecRuleEngine On
+	`
+}
+```
+
+The same error appears if an `@` path is prefixed with a directory, as in `Include /etc/caddy/rules/@owasp_crs/*.conf`. The `@` must start the path.
+
+### Debug log file is created but stays empty
+`SecDebugLogLevel` on its own is not enough. Coraza's debug output is routed through Caddy's logger, and Coraza's debug and trace levels are both emitted at Caddy's `DEBUG` level. Caddy logs at `INFO` by default, so the entries are filtered out before they reach the file.
+
+Raise Caddy's log level as well:
+
+```caddy
+{
+	log {
+		level DEBUG
+	}
+}
+```
+
+With `SecDebugLogLevel 9` and Caddy at its default level the file stays at 0 bytes; with Caddy at `DEBUG` it fills as expected. The audit log is written by Coraza directly and is unaffected, which is why it can have contents while the debug log looks broken.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -38,7 +38,7 @@ Use a value appropriate for your application. Lower values improve resilience to
 ### `open @coraza.conf-recommended: no such file or directory`
 The `@`-prefixed CRS paths are served from a ruleset compiled into the binary, not read from disk, and the `load_owasp_crs` field is what makes them resolvable. Without it Caddy treats `@coraza.conf-recommended` as a literal filename and fails at startup:
 
-```
+```text
 invalid WAF config from string: failed to readfile:
   open @coraza.conf-recommended: no such file or directory
 ```


### PR DESCRIPTION
Six open issues reduce to two undocumented behaviours. Both are verified below rather than inferred.

## 1. What `@` paths are, and that `load_owasp_crs` is required

Closes the confusion behind #214, #169, #143 and #148.

`load_owasp_crs` is what swaps in the embedded CRS filesystem (`coraza.go:108`, `WithRootFS`). Without it the `@` paths are treated as literal filenames. Reproduced both directions:

```console
# no load_owasp_crs
Error: ... invalid WAF config from string: failed to readfile:
  open @coraza.conf-recommended: no such file or directory

# with load_owasp_crs
Valid configuration
```

That single fact explains the cluster:

| issue | symptom | cause |
|---|---|---|
| #214 | `no such file or directory` on Linux | `load_owasp_crs` omitted |
| #169 | same, Windows path separators | same |
| #143 | "do I need to mount the rulesets?" | not knowing they are compiled in |
| #148 | `Include /etc/caddy/rules/@owasp_crs/*.conf` | prefixing a real path onto an `@` path |

The README already showed `load_owasp_crs`, but never said what `@` means or that the two are linked, so the failure mode was invisible until startup.

## 2. Debug logging has two gates

Closes #206 ("the file gets created but stays empty").

Coraza's debug output is routed through Caddy's zap logger (`coraza.go:106`), and `Debug()` and `Trace()` both emit at zap's **Debug** level (`logger.go:93-99`). Caddy defaults to `INFO`, so `SecDebugLogLevel 9` alone yields nothing. Measured with an otherwise identical config:

| Caddy log level | `SecDebugLog` file |
|---|---|
| default (INFO) | **0 bytes** |
| `log { level DEBUG }` | 5672 bytes |

This also explains the reporter's observation that the audit log had contents while the debug log did not — the audit log is written by Coraza directly and never passes through zap.

## 3. Memoization, documented accurately

#141 asks to document a `memoize_builders` flag, and #258 advises "using the memoize flag while compiling". **No such build tag exists.** In coraza v3.7.0 the tags are:

| file | build tag | behaviour |
|---|---|---|
| `sync.go` | `!tinygo && !coraza.no_memoize` | memoization on — **the default** |
| `nosync.go` | `tinygo && !coraza.no_memoize` | TinyGo variant |
| `noop.go` | `coraza.no_memoize` | disabled |

So memoization is on by default and the tag only turns it *off*. Documenting #141 as written would have described a feature that does not exist.

Worth noting for #258/#76 separately: the memoize cache is process-global and released when a WAF is closed, and this module already closes pooled WAFs via `caddy.Destructor` (`coraza.go:46`). The mechanism jptosso described as missing in #258 now exists, so those memory reports are worth re-testing against current main — I have not done that here, so I am not claiming they are fixed.

## Verification

Every Caddyfile snippet added was extracted verbatim from the rendered Markdown and run through `caddy validate`:

```console
doc1 (troubleshooting: load_owasp_crs)  -> Valid configuration
doc2 (troubleshooting: log level DEBUG) -> Valid configuration
doc3 (README CRS example)               -> Valid configuration
```

Docs only — no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified how to use embedded CRS paths, including the required loading option and correct path syntax.
  - Added guidance for resolving startup errors when CRS loading is omitted.
  - Documented rule-compilation memoization, cache behavior, and the option to disable it.
  - Expanded troubleshooting steps for missing CRS paths and empty debug logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->