### PR TITLE
fix: flush and hijack through the response writer Unwrap chain

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -31,6 +31,22 @@ func (h *hijackerTracker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return conn, rw, nil
 }
 
+// hijackerOf returns the http.Hijacker reachable from w, unwrapping response
+// writers that only expose it further down the chain, as caddy's
+// ResponseWriterWrapper does.
+func hijackerOf(w http.ResponseWriter) (http.Hijacker, bool) {
+	for {
+		if h, ok := w.(http.Hijacker); ok {
+			return h, true
+		}
+		u, ok := w.(interface{ Unwrap() http.ResponseWriter })
+		if !ok {
+			return nil, false
+		}
+		w = u.Unwrap()
+	}
+}
+
 // Copied from https://github.com/corazawaf/coraza/blob/main/http/interceptor.go
 // rwInterceptor intercepts the ResponseWriter, so it can track response size
 // and returned status code.
@@ -175,10 +191,12 @@ func (i *rwInterceptor) Flush() {
 
 	if i.allowFlushing {
 		if i.isWriteHeaderFlush {
-			// only propagate flush if the headers have been flushed already
-			if fl, ok := i.w.(http.Flusher); ok {
-				fl.Flush()
-			}
+			// only propagate flush if the headers have been flushed already.
+			// ResponseController is used instead of an http.Flusher type
+			// assertion because caddy wraps the response writer in types that
+			// only expose the flusher further down the Unwrap chain.
+			//nolint:bodyclose
+			_ = http.NewResponseController(i.w).Flush()
 		}
 
 	}
@@ -287,7 +305,7 @@ func wrap(w http.ResponseWriter, r *http.Request, tx types.Transaction) (
 	}
 
 	var (
-		hijacker, isHijacker = i.w.(http.Hijacker)
+		hijacker, isHijacker = hijackerOf(i.w)
 		pusher, isPusher     = i.w.(http.Pusher)
 	)
 

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -168,6 +168,15 @@ func (hijackerPusherResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error
 
 func (hijackerPusherResponseWriter) Push(string, *http.PushOptions) error { return nil }
 
+// unwrapOnlyResponseWriter mimics caddy's ResponseWriterWrapper: it exposes
+// neither Flush nor Hijack itself, only the writer behind Unwrap does.
+type unwrapOnlyResponseWriter struct{ inner http.ResponseWriter }
+
+func (w unwrapOnlyResponseWriter) Header() http.Header         { return w.inner.Header() }
+func (w unwrapOnlyResponseWriter) Write(b []byte) (int, error) { return w.inner.Write(b) }
+func (w unwrapOnlyResponseWriter) WriteHeader(statusCode int)  { w.inner.WriteHeader(statusCode) }
+func (w unwrapOnlyResponseWriter) Unwrap() http.ResponseWriter { return w.inner }
+
 func TestWrapPreservesInterfaces(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	rec := httptest.NewRecorder()
@@ -182,6 +191,7 @@ func TestWrapPreservesInterfaces(t *testing.T) {
 		{"hijacker writer", hijackerResponseWriter{rec}, true, false},
 		{"pusher writer", pusherResponseWriter{rec}, false, true},
 		{"hijacker+pusher writer", hijackerPusherResponseWriter{rec}, true, true},
+		{"hijacker behind unwrap", unwrapOnlyResponseWriter{hijackerResponseWriter{rec}}, true, false},
 	}
 
 	for _, tt := range tests {
@@ -423,6 +433,25 @@ func TestFlushDelegatesToUnderlyingFlusher(t *testing.T) {
 
 	require.True(t, i.isWriteHeaderFlush, "status code should have been flushed")
 	require.True(t, rec.Flushed, "underlying http.Flusher should have been called")
+}
+
+func TestFlushDelegatesThroughUnwrap(t *testing.T) {
+	waf := newWAF(t, `
+		SecRuleEngine On
+		SecResponseBodyAccess Off
+	`)
+	tx := waf.NewTransaction()
+	defer tx.Close()
+
+	rec := httptest.NewRecorder()
+	i := &rwInterceptor{w: unwrapOnlyResponseWriter{rec}, tx: tx, proto: "HTTP/1.1", statusCode: 200}
+
+	i.WriteHeader(http.StatusOK)
+	// Write triggers flushWriteHeader for the non-buffered path
+	_, _ = i.Write([]byte("data"))
+	i.Flush()
+
+	require.True(t, rec.Flushed, "flusher behind Unwrap should have been called")
 }
 
 // TestConcurrentStreamingResponseFlush uses real HTTP connections to verify


### PR DESCRIPTION
## What

`Flush()` now propagates via `http.NewResponseController(i.w).Flush()`, and `wrap()` looks for the `http.Hijacker` along the `Unwrap()` chain instead of type-asserting it on the immediate writer.

## Why

Caddy [#7913](https://github.com/caddyserver/caddy/pull/7913) wraps every response writer in `*caddyhttp.IdleTimeoutWriter`, which embeds `*ResponseWriterWrapper` and therefore implements only `Header`/`Write`/`WriteHeader`/`Push`/`ReadFrom`/`Unwrap`. The interceptor asserted the optional interfaces directly on that writer, so both lookups failed:

- `i.w.(http.Flusher)` returned false, making `Flush()` a silent no-op. Streaming responses were held in net/http's buffer until the handler returned. This is what the Nightly Caddy e2e job reports as `[Fail] stream ended too quickly; expected progressive delivery; response probably buffered by coraza` (failing since 2026-08-22, first seen in run [32552023996](https://github.com/corazawaf/coraza-caddy/actions/runs/32552023996)).
- `i.w.(http.Hijacker)` returned false, so the wrapped writer no longer advertised `Hijack` and WebSocket upgrades stopped working.

Both come from the same cause, so both are fixed here.

## Verification

- e2e 10/10 against caddy `v2.11.5-0.20260825041933-51db7f0313b9`, including the SSE stream test
- `curl -N` on `/sse` shows events arriving progressively instead of all at once at the end
- Two tests cover a writer that exposes `Flush`/`Hijack` only behind `Unwrap`; both fail without the change
- `go test -race ./...` and `golangci-lint run ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with wrapped response writers.
  * Preserved connection hijacking support when response writers are layered.
  * Ensured flush operations reach the underlying writer through wrapper layers.

* **Tests**
  * Added coverage for hijacking and flushing through wrapped response writers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->