### PR TITLE
Set transaction ServerName from request Host (audit lines report [hostname ""])

### DIFF
--- a/coraza.go
+++ b/coraza.go
@@ -65,6 +65,12 @@ type txMeta struct {
 	cnameTarget string
 }
 
+// Registry is package-level on purpose: WAF instances are pooled by config and
+// shared across module instances, so the matched-rule callback (bound to the
+// pooled instance) must resolve metadata stored by whichever module instance
+// served the request. Transaction ids are globally unique.
+var txMetaRegistry sync.Map
+
 type corazaModule struct {
 	// dotCMS: tx id -> *txMeta; populated per request, cleaned on close.
 	txMeta *sync.Map
@@ -91,7 +97,6 @@ func (corazaModule) CaddyModule() caddy.ModuleInfo {
 // Provision implements caddy.Provisioner.
 func (m *corazaModule) Provision(ctx caddy.Context) error {
 	m.logger = ctx.Logger(m)
-	m.txMeta = &sync.Map{}
 	m.poolKey = m.computePoolKey()
 
 	val, loaded, err := wafPool.LoadOrNew(m.poolKey, func() (caddy.Destructor, error) {
@@ -226,14 +231,13 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	// target from the cname_router_resolve stage's vars) for the matched-rule
 	// callback — upstream's ErrorLog writes the unset server IP into the
 	// [hostname] slot, losing the host entirely.
-	// (txMeta is nil in unprovisioned module literals — skip attribution.)
-	if m.txMeta != nil {
+	{
 		meta := &txMeta{host: r.Host, uri: r.RequestURI}
 		if v, ok := caddyhttp.GetVar(r.Context(), "cname_target").(string); ok && v != "" {
 			meta.cnameTarget = v
 		}
-		m.txMeta.Store(id, meta)
-		defer m.txMeta.Delete(id)
+		txMetaRegistry.Store(id, meta)
+		defer txMetaRegistry.Delete(id)
 	}
 	tx.SetServerName(r.Host)
 	defer func() {
@@ -354,7 +358,7 @@ func (m *corazaModule) newErrorCb() func(types.MatchedRule) {
 	return func(mr types.MatchedRule) {
 		logMsg := mr.ErrorLog()
 		var fields []zap.Field
-		if meta, ok := m.txMeta.Load(mr.TransactionID()); ok {
+		if meta, ok := txMetaRegistry.Load(mr.TransactionID()); ok {
 			if tm, ok := meta.(*txMeta); ok {
 				fields = append(fields,
 					zap.String("host", tm.host),

--- a/coraza.go
+++ b/coraza.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -55,7 +56,18 @@ func (p *pooledWAF) Destruct() error {
 }
 
 // corazaModule is a Web Application Firewall implementation for Caddy.
+// txMeta carries per-request attribution for matched-rule logging: upstream
+// ErrorLog writes the (unset) server IP into the [hostname] slot, so the host,
+// URI and resolved CNAME target are attached as structured zap fields instead.
+type txMeta struct {
+	host        string
+	uri         string
+	cnameTarget string
+}
+
 type corazaModule struct {
+	// dotCMS: tx id -> *txMeta; populated per request, cleaned on close.
+	txMeta *sync.Map
 	// deprecated
 	Include []string `json:"include"`
 
@@ -79,6 +91,7 @@ func (corazaModule) CaddyModule() caddy.ModuleInfo {
 // Provision implements caddy.Provisioner.
 func (m *corazaModule) Provision(ctx caddy.Context) error {
 	m.logger = ctx.Logger(m)
+	m.txMeta = &sync.Map{}
 	m.poolKey = m.computePoolKey()
 
 	val, loaded, err := wafPool.LoadOrNew(m.poolKey, func() (caddy.Destructor, error) {
@@ -102,7 +115,7 @@ func (m *corazaModule) Provision(ctx caddy.Context) error {
 // buildWAF creates a new coraza.WAF from the module's configuration.
 func (m *corazaModule) buildWAF() (coraza.WAF, error) {
 	config := coraza.NewWAFConfig().
-		WithErrorCallback(newErrorCb(m.logger)).
+		WithErrorCallback(m.newErrorCb()).
 		WithDebugLogger(newLogger(m.logger))
 
 	if m.LoadOWASPCRS {
@@ -209,6 +222,19 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	// unable to tell which host a warning belongs to. Set BEFORE
 	// ProcessRequestHeaders (see types.Transaction.SetServerName docs) —
 	// processRequest below calls it.
+	// dotCMS: stash per-transaction attribution (host, URI, resolved CNAME
+	// target from the cname_router_resolve stage's vars) for the matched-rule
+	// callback — upstream's ErrorLog writes the unset server IP into the
+	// [hostname] slot, losing the host entirely.
+	// (txMeta is nil in unprovisioned module literals — skip attribution.)
+	if m.txMeta != nil {
+		meta := &txMeta{host: r.Host, uri: r.RequestURI}
+		if v, ok := caddyhttp.GetVar(r.Context(), "cname_target").(string); ok && v != "" {
+			meta.cnameTarget = v
+		}
+		m.txMeta.Store(id, meta)
+		defer m.txMeta.Delete(id)
+	}
 	tx.SetServerName(r.Host)
 	defer func() {
 		tx.ProcessLogging()
@@ -324,25 +350,34 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 	return m, err
 }
 
-func newErrorCb(logger *zap.Logger) func(types.MatchedRule) {
+func (m *corazaModule) newErrorCb() func(types.MatchedRule) {
 	return func(mr types.MatchedRule) {
 		logMsg := mr.ErrorLog()
+		var fields []zap.Field
+		if meta, ok := m.txMeta.Load(mr.TransactionID()); ok {
+			if tm, ok := meta.(*txMeta); ok {
+				fields = append(fields,
+					zap.String("host", tm.host),
+					zap.String("uri", tm.uri),
+					zap.String("cname_target", tm.cnameTarget))
+			}
+		}
 		switch mr.Rule().Severity() {
 		case types.RuleSeverityEmergency,
 			types.RuleSeverityAlert,
 			types.RuleSeverityCritical,
 			types.RuleSeverityError:
-			logger.Error(logMsg)
+			m.logger.Error(logMsg, fields...)
 		case types.RuleSeverityWarning:
-			logger.Warn(logMsg)
+			m.logger.Warn(logMsg, fields...)
 		case types.RuleSeverityNotice:
-			logger.Info(logMsg)
+			m.logger.Info(logMsg, fields...)
 		case types.RuleSeverityInfo:
-			logger.Info(logMsg)
+			m.logger.Info(logMsg, fields...)
 		case types.RuleSeverityDebug:
-			logger.Debug(logMsg)
+			m.logger.Debug(logMsg, fields...)
 		default:
-			logger.Warn(logMsg)
+			m.logger.Warn(logMsg, fields...)
 		}
 	}
 }

--- a/coraza.go
+++ b/coraza.go
@@ -203,6 +203,13 @@ func (m corazaModule) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	}
 
 	tx := m.waf.NewTransactionWithID(id)
+	// dotCMS patch: populate the transaction server name so every matched-rule
+	// audit line carries [hostname "<request host>"]. Upstream leaves it empty
+	// (the interceptor never sets it), which makes multi-site deployments
+	// unable to tell which host a warning belongs to. Set BEFORE
+	// ProcessRequestHeaders (see types.Transaction.SetServerName docs) —
+	// processRequest below calls it.
+	tx.SetServerName(r.Host)
 	defer func() {
 		tx.ProcessLogging()
 		if err := tx.Close(); err != nil {

--- a/coraza_test.go
+++ b/coraza_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -462,7 +463,7 @@ func TestNewErrorCb(t *testing.T) {
 
 			waf, err := corazaWAF.NewWAF(
 				corazaWAF.NewWAFConfig().
-					WithErrorCallback(newErrorCb(zap.New(core))).
+					WithErrorCallback((&corazaModule{logger: zap.New(core), txMeta: &sync.Map{}}).newErrorCb()).
 					WithDirectives(fmt.Sprintf(
 						`SecRuleEngine On
 						SecRule REQUEST_URI "/trigger" "id:1,phase:1,pass,log,severity:%d"`,
@@ -489,7 +490,7 @@ func TestNewErrorCb(t *testing.T) {
 
 		waf, err := corazaWAF.NewWAF(
 			corazaWAF.NewWAFConfig().
-				WithErrorCallback(newErrorCb(zap.New(core))).
+				WithErrorCallback((&corazaModule{logger: zap.New(core), txMeta: &sync.Map{}}).newErrorCb()).
 				WithDirectives(
 					`SecRuleEngine On
 					SecRule REQUEST_URI "/trigger" "id:1,phase:1,pass,log"`,


### PR DESCRIPTION
The interceptor never populates the transaction server name, so every matched-rule audit line emits `[hostname ""]` — in multi-site deployments the warnings cannot be attributed to a host. One line: `tx.SetServerName(r.Host)` before `processRequest` (the docs require SetServerName before ProcessRequestHeaders, which processRequest calls). Verified against CRS in a multi-tenant edge: warnings now carry the real Host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved transaction metadata handling for more reliable request attribution across WAF processing.
  * Audit log entries for matched rules include the request hostname as the server name.
  * WAF error logs include structured request details—host, URI, and resolved CNAME target—at all severity levels.
  * Request-specific metadata remains accurately associated with the relevant transaction, including when multiple WAF instances process requests concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->